### PR TITLE
Remove dependency for arc sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "@enhance/starter-project",
   "version": "1.0.1",
   "scripts": {
-    "start": "sandbox"
-  },
-  "devDependencies": {
-    "@architect/sandbox": "latest"
+    "start": "begin dev"
   },
   "dependencies": {
     "@enhance/arc-plugin-enhance": "latest"

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,15 @@
 
 adds file based routing w server rendered custom elements
 
+## Prerequisite
+
+- Install the [Begin CLI](https://github.com/beginner-corp/cli#installing)
+
 ## project structure
 
 ```
 app
-├── elements .......... define pure functions that return custom elements 
+├── elements .......... define pure functions that return custom elements
 │   ├── footer.mjs
 │   └── header.mjs
 ├── elements.mjs ...... define tag names for custom element definitions
@@ -16,9 +20,9 @@ app
 
 ### Decisions
 
-file based routing using leading `$` for dynamic parameters reasoning 
+file based routing using leading `$` for dynamic parameters reasoning
 
 - `$` is safe on windows and linux UNLESS its trailing in which case thats a hidden file in windows
 - `:` is illegal in windows file paths
-- `*` will expand in various system shells creating ambiguity 
-- `.` is meaningful in system shells (current dir) and completions with `..` and/or `...` creates ambiguity 
+- `*` will expand in various system shells creating ambiguity
+- `.` is meaningful in system shells (current dir) and completions with `..` and/or `...` creates ambiguity


### PR DESCRIPTION
I'm making the assumption that folks will already have the Begin CLI installed which will make the installation of npm dependencies much faster.

Signed-off-by: macdonst <simon.macdonald@gmail.com>