### PR TITLE
Include styles as <link> for local, <style> for deploy

### DIFF
--- a/app/head.mjs
+++ b/app/head.mjs
@@ -1,11 +1,17 @@
 import { getStyles } from '@enhance/arc-plugin-styles'
 
-const { linkTag } = getStyles
-
 export default function Head(state) {
   const { store = {} } = state
+
   // pageTitle is set in /app/preflight.mjs
   const { pageTitle = '' } = store
+
+  // Enhance Styles
+  // CSS will be included as a <link> tag for local development.
+  // For deployments, CSS will be included as a <style> tag in order to eliminate the blocking network request created by <link> tags.
+  const styles = process.env.ARC_LOCAL
+    ? getStyles.linkTag()
+    : getStyles.styleTag()
 
   return `
     <!DOCTYPE html>
@@ -14,7 +20,7 @@ export default function Head(state) {
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <title>${pageTitle}</title>
-      ${linkTag()}
+      ${styles}
       <link rel="icon" href="/_public/favicon.svg">
       <meta name="description" content="The HTML first full stack web framework.">
     </head>


### PR DESCRIPTION
Enhance Styles will now, by default, include styles as a `<link>` tag for local development, and as a `<style>` tag for deployments. This improves performance by cutting out a blocking network request on deployments, but keeps source code cleaner in local development. Users can always opt to modify this in their own projects.

WPT before (over 4G):
<img width="1448" alt="image" src="https://github.com/enhance-dev/enhance-starter-project/assets/1713932/ebff1b0d-dd02-4ab5-9017-1a820ff8e7da">


WPT after:
<img width="1432" alt="image" src="https://github.com/enhance-dev/enhance-starter-project/assets/1713932/64658252-b0db-456e-af1f-237d9840f5fd">
